### PR TITLE
migrate to customize-cra

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
-const { injectBabelPlugin } = require('react-app-rewired')
+const { addBabelPlugin } = require('customize-cra');
 
 function rewireInlineImportGraphqlAst(config, env, gqlPluginOptions = {}) {
   const pluginOptions = Object.assign({}, gqlPluginOptions, { nodePath: process.env.NODE_PATH })
-  return injectBabelPlugin(['import-graphql', pluginOptions], config)
+  return addBabelPlugin(['import-graphql', pluginOptions])(config)
 }
 
 module.exports = rewireInlineImportGraphqlAst

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-app-rewire-inline-import-graphql-ast",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "A plugin to add the inline-import-graphql-ast Babel plugin to create-react-app with react-app-rewired",
   "repository": {
     "type": "git",
@@ -9,9 +9,10 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "babel-plugin-import-graphql": "^2.6.2"
+    "babel-plugin-import-graphql": "^2.6.2",
+    "customize-cra": "^0.2.12"
   },
   "peerDependencies": {
-    "react-app-rewired": "^1.3.8"
+    "react-app-rewired": "^2.0.1"
   }
 }


### PR DESCRIPTION
When I use this with newer version of react-app-rewired (^2.x.x) I have got an error:

```
The "injectBabelPlugin" helper has been deprecated as of v2.0. You can use customize-cra plugins in replacement - https://github.com/arackaf/customize-cra#available-plugins
error Command failed with exit code 1.
```

This PR migrates to customize-cra helpers